### PR TITLE
Switch APCP_surface to sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ bower_components/
 .grunt/
 src/vendor/
 dist/
+
+venv
+.venv

--- a/regrid_ExactExtract.py
+++ b/regrid_ExactExtract.py
@@ -109,7 +109,7 @@ def csv_to_netcdf(num_catchments, weighted_csv_files, aorc_ncfile):
         #since ExactExtract module doesn't account for scale_factor and offset
         # keys for a given variable, we will have to finish calculating the lumped
         # sum for the ExactExtract csv files
-        df['APCP_surface_weighted_mean'] = df['APCP_surface_weighted_mean']*scale_factor[0] + add_offset[0]
+        df['APCP_surface_weighted_sum'] = df['APCP_surface_weighted_sum']*scale_factor[0] + add_offset[0]
         df['DLWRF_surface_weighted_mean'] = df['DLWRF_surface_weighted_mean']*scale_factor[1] + add_offset[1]
         df['DSWRF_surface_weighted_mean'] = df['DSWRF_surface_weighted_mean']*scale_factor[2] + add_offset[2]
         df['PRES_surface_weighted_mean'] = df['PRES_surface_weighted_mean']*scale_factor[3] + add_offset[3]
@@ -119,7 +119,7 @@ def csv_to_netcdf(num_catchments, weighted_csv_files, aorc_ncfile):
         df['VGRD_10maboveground_weighted_mean'] = df['VGRD_10maboveground_weighted_mean']*scale_factor[7] + add_offset[7]
 
         # Now add the ExactExtract csv data to netcdf variables 
-        APCP_surface[:,i] = df['APCP_surface_weighted_mean'].values
+        APCP_surface[:,i] = df['APCP_surface_weighted_sum'].values
         DLWRF_surface[:,i] = df['DLWRF_surface_weighted_mean'].values
         DSWRF_surface[:,i] = df['DSWRF_surface_weighted_mean'].values
         PRES_surface[:,i] = df['PRES_surface_weighted_mean'].values
@@ -304,7 +304,10 @@ if __name__ == '__main__':
   
     avg_variable_technique = '' 
     for i in np.arange(len(AORC_met_vars)):
-        avg_variable_technique += ' -s "weighted_mean('+AORC_met_vars[i]+')"' 
+        if AORC_met_vars[i] == 'APCP_surface':
+            avg_variable_technique += ' -s "weighted_sum('+AORC_met_vars[i]+')"' 
+        else:
+            avg_variable_technique += ' -s "weighted_mean('+AORC_met_vars[i]+')"' 
 
 
 


### PR DESCRIPTION
Use `weighted_sum` instead of `weighted_mean` for `APCP_surface` 

## Additions

- Also added `venv` and `.venv` to .gitignore

## Removals

-

## Changes

- Use `weighted_sum` instead of `weighted_mean` for `APCP_surface` 

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Linux

