### PR TITLE
Modify `get_grid_{x,y,z}` to return coordinate arrays matching grid shape in gridded mode

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -1099,7 +1099,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_x(self, grid_id: int, x: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id:
-                x[:] = np.unique(grid.grid_x)
+                if self._grid_type == 'gridded':
+                    x[:] = np.unique(grid.grid_x)
+                else:
+                    x[:] = grid.grid_x
                 return x
         raise ValueError(f"get_grid_x: grid_id {grid_id} unknown")
 
@@ -1107,7 +1110,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_y(self, grid_id: int, y: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id: 
-                y[:] = np.unique(grid.grid_y)
+                if self._grid_type == 'gridded':
+                    y[:] = np.unique(grid.grid_y)
+                else:
+                    y[:] = grid.grid_y
                 return y
         raise ValueError(f"get_grid_y: grid_id {grid_id} unknown")
 
@@ -1115,7 +1121,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_z(self, grid_id: int, z: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id: 
-                z[:] = np.unique(grid.grid_z)
+                if self._grid_type == 'gridded':
+                    z[:] = np.unique(grid.grid_z)
+                else:
+                    z[:] = grid.grid_z
                 return z
         raise ValueError(f"get_grid_z: grid_id {grid_id} unknown")
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -1099,7 +1099,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_x(self, grid_id: int, x: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id:
-                x[:] = grid.grid_x
+                x[:] = np.unique(grid.grid_x)
                 return x
         raise ValueError(f"get_grid_x: grid_id {grid_id} unknown")
 
@@ -1107,7 +1107,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_y(self, grid_id: int, y: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id: 
-                y[:] = grid.grid_y
+                y[:] = np.unique(grid.grid_y)
                 return y
         raise ValueError(f"get_grid_y: grid_id {grid_id} unknown")
 
@@ -1115,7 +1115,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     def get_grid_z(self, grid_id: int, z: NDArray[np.float64]) -> NDArray[np.float64]:
         for grid in self._grids:
             if grid_id == grid.id: 
-                z[:] = grid.grid_z
+                z[:] = np.unique(grid.grid_z)
                 return z
         raise ValueError(f"get_grid_z: grid_id {grid_id} unknown")
 


### PR DESCRIPTION
This PR changes the output of `get_grid_{x,y,z}` to return unique coordinate values. Currently, the length of the output array is equal to `get_grid_size`, which is the product of the values of `get_grid_shape`. However, for uniform_rectilinear grids, we'd expect the array sizes to match the shape of the a given dimension, rather than the entire space.

@jduckerOWP 

## Changes

- Changes `get_grid_{x,y,z}` to apply `np.unique` to grid coordinates if grid_type is 'gridded'.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
